### PR TITLE
fix: Add CODEOWNERS for Enterprise/B2B squads 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Grant all Enterprise/B2B squads merge permission to entire repo.
+* @edx/enterprise-titans @edx/enterprise-markhors @edx/enterprise-sunrise @edx/enterprise-lakshy

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,7 @@ frontend-app-enterprise-public-catalog
 Introduction
 ------------
 
+
 This application is a public facing catalog page for use by edX consumers to find courses in catalogs before deciding to enroll.
 
 The dev server is running at `http://localhost:8735 <http://localhost:8735>`_.


### PR DESCRIPTION
GSRE-3457

Add CODEOWNERS for Enterprise/B2B squads 
