### PR TITLE
chore: bump @2uinc/frontend-enterprise-catalog-search to ^11.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@2uinc/frontend-enterprise-catalog-search": "11.1.1",
+        "@2uinc/frontend-enterprise-catalog-search": "^11.2.1",
         "@2uinc/frontend-enterprise-hotjar": "7.2.2",
-        "@2uinc/frontend-enterprise-utils": "10.0.2",
+        "@2uinc/frontend-enterprise-utils": "10.0.4",
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@edx/brand-openedx": "^1.2.1",
         "@edx/frontend-component-footer": "14.7.1",
@@ -61,12 +61,12 @@
       }
     },
     "node_modules/@2uinc/frontend-enterprise-catalog-search": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@2uinc/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-11.1.1.tgz",
-      "integrity": "sha512-O9klsesjaF2YvV4IfOvbf/vG823UOxvdhgQd9TFMuoYlu8ye7Tbd9gn88J/m8szCSG4xDU8bPMZYiuAEWetH9Q==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@2uinc/frontend-enterprise-catalog-search/-/frontend-enterprise-catalog-search-11.2.1.tgz",
+      "integrity": "sha512-pcbzhazL9ZXTOjt7XcY+AGS07suSR7oR71Aucs4v26feTlIf8ErosAfSh4LDiEX5lvk8tIVxGwGSnNbs/mn/Dw==",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@2uinc/frontend-enterprise-utils": "^10.0.2",
+        "@2uinc/frontend-enterprise-utils": "^10.0.4",
         "classnames": "^2.5.1",
         "lodash.debounce": "^4.0.8",
         "prop-types": "^15.8.1"
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@2uinc/frontend-enterprise-utils": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@2uinc/frontend-enterprise-utils/-/frontend-enterprise-utils-10.0.2.tgz",
-      "integrity": "sha512-J2aT8zdDaar4SxpYX/s+zWq79pYL72Wjp/JZvizrp9lrbozRZHV1QK3qK6fytaIw3ZYI4PmuFm3cciLnl7pNpA==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@2uinc/frontend-enterprise-utils/-/frontend-enterprise-utils-10.0.4.tgz",
+      "integrity": "sha512-kdbnE34hiO3jBN6+WUwXHbqGatxoZhmGFLldrdjKWolN4/IU46GEiLZZiapRBy0FRO04fGIC6z2jTrvNIydPAQ==",
       "license": "AGPL-3.0",
       "dependencies": {
         "history": "^4.10.1"
@@ -2592,7 +2592,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
       "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2604,7 +2603,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
       "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2615,7 +2613,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
       "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3726,7 +3723,6 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
       "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3755,7 +3751,6 @@
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -4242,7 +4237,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4282,7 +4276,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4303,7 +4296,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4324,7 +4316,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4345,7 +4336,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4366,7 +4356,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4387,7 +4376,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4408,7 +4396,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4429,7 +4416,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4450,7 +4436,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4471,7 +4456,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4492,7 +4476,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4513,7 +4496,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4534,7 +4516,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5067,7 +5048,6 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5877,7 +5857,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5891,7 +5870,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5905,7 +5883,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5919,7 +5896,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5933,7 +5909,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5947,7 +5922,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5961,7 +5935,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5975,7 +5948,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5989,7 +5961,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6003,7 +5974,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6017,7 +5987,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6031,7 +6000,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6045,7 +6013,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6059,7 +6026,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6073,7 +6039,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6087,7 +6052,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6104,7 +6068,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6118,7 +6081,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6132,7 +6094,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7322,7 +7283,6 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.4.4.tgz",
       "integrity": "sha512-Q8yxM1eLhJfuM7KXVP3zjhBvtMJCYRByoTT+wHXjpdMELv0xICFJX+1w4c7csa+WZEOsq4ItJ4RGwvzid6m/dw==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -7348,7 +7308,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
       "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
@@ -7359,7 +7318,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -7370,7 +7328,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
       "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -7393,7 +7350,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.2.2.tgz",
       "integrity": "sha512-g+ueNGKkrjMazDG3elZO1pNs3HY5+mMmOet1jtKyhOaCnkLzitxf26z7hoAEkDNgdNmnc1KIlt/dw6Po6xZMpA==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -9043,7 +8999,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -15372,7 +15327,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:stage": "npm run start -- --config=webpack.dev-stage.config.js",
     "start:with-theme": "paragon install-theme && npm run start && npm install",
     "start:stage:with-theme": "paragon install-theme && npm run start:stage && npm install",
-    "test": "fedx-scripts jest --transformIgnorePatterns \"node_modules/(?!@edx/frontend-app-enterprise-public-catalog)/\" --env=jsdom --coverage --passWithNoTests",
+    "test": "fedx-scripts jest --transformIgnorePatterns \"node_modules/(?!@2uinc/frontend-enterprise-catalog-search)/\" --env=jsdom --coverage --passWithNoTests",
     "test:watch": "npm run test -- --watch"
   },
   "husky": {
@@ -37,9 +37,9 @@
     "url": "https://github.com/openedx/frontend-app-enterprise-public-catalog/issues"
   },
   "dependencies": {
-    "@2uinc/frontend-enterprise-catalog-search": "11.1.1",
+    "@2uinc/frontend-enterprise-catalog-search": "^11.2.1",
     "@2uinc/frontend-enterprise-hotjar": "7.2.2",
-    "@2uinc/frontend-enterprise-utils": "10.0.2",
+    "@2uinc/frontend-enterprise-utils": "10.0.4",
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
     "@edx/brand-openedx": "^1.2.1",
     "@edx/frontend-component-footer": "14.7.1",


### PR DESCRIPTION
ENT-12100

Body: "Bumps @2uinc/frontend-enterprise-catalog-search to ^11.2.1, which adds the 'Recently added' message for the is_new_content facet's true value. Needed by ENT-12100 (Latest Offerings filter, PR #13) before that PR can render the correct label."

11.1.1 predates the is_new_content boolean facet's "Recently added" label (added upstream in 11.2.1, see frontend-app-learner-portal-enterprise's own bump commit 563e2468 for the same package/reason). Bumping to pick that up.

