### PR TITLE
refactor: rename NewContentAwareSearchFilters to SearchFacetFiltersOverride

### DIFF
--- a/src/components/catalogs/CatalogSearch.jsx
+++ b/src/components/catalogs/CatalogSearch.jsx
@@ -26,7 +26,7 @@ import {
   QUERY_TITLE_REFINEMENT,
 } from '../../constants';
 import CatalogSearchResults from '../catalogSearchResults/CatalogSearchResults';
-import NewContentAwareSearchFilters from './NewContentAwareSearchFilters';
+import SearchFacetFiltersOverride from './SearchFacetFiltersOverride';
 import CatalogInfoModal from '../catalogInfoModal/CatalogInfoModal';
 import {
   mapAlgoliaObjectToProgram,
@@ -291,9 +291,7 @@ const CatalogSearch = () => {
               disableSuggestionRedirect
               suggestionSubmitOverride={suggestedCourseOnClick}
               hideSearchBox={hideSearchBox}
-              filterComponents={features.NEW_CONTENT_FACET && (
-                <NewContentAwareSearchFilters variant="default" />
-              )}
+              filterComponents={<SearchFacetFiltersOverride variant="default" />}
             />
             ) }
           </div>

--- a/src/components/catalogs/SearchFacetFiltersOverride.jsx
+++ b/src/components/catalogs/SearchFacetFiltersOverride.jsx
@@ -1,14 +1,13 @@
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { FacetListRefinement, SearchContext } from '@2uinc/frontend-enterprise-catalog-search';
 import { NEW_CONTENT_REFINEMENT } from '../../constants';
+import features from '../../config';
 
 const TRUE_VALUE = 'true';
 const sortItemsByLabelAsc = (items) => [...items].sort((a, b) => a.label.localeCompare(b.label));
 
-// Label stays `true` (not renamed) since FacetListBase dispatches item.label as the
-// refinement value — renaming it would break the match against Algolia's is_new_content.
-// messages.js maps it to "Recently added" for display.
+// Label stays `true` (not renamed) — FacetListBase dispatches it as the refinement value.
 const newContentTransform = (items) => items.filter(({ label }) => label === TRUE_VALUE);
 
 const getTransformItems = ({ attribute, isSortedAlphabetical }) => {
@@ -21,11 +20,24 @@ const getTransformItems = ({ attribute, isSortedAlphabetical }) => {
   return (items) => items;
 };
 
-// Same as the shared package's SearchFilters, but collapses is_new_content to just the true row.
-const NewContentAwareSearchFilters = ({ variant }) => {
+// Drops is_new_content when its flag is off; every other facet passes through.
+const filterFacetItems = ({ attribute }) => {
+  if (attribute === NEW_CONTENT_REFINEMENT && !features.NEW_CONTENT_FACET) {
+    return false;
+  }
+  return true;
+};
+
+// Like the shared package's SearchFilters, but collapses is_new_content to its true row.
+const SearchFacetFiltersOverride = ({ variant }) => {
   const { refinements, searchFacetFilters } = useContext(SearchContext);
 
-  return searchFacetFilters.map(({
+  const updatedFacetFilter = useMemo(
+    () => searchFacetFilters.filter(filterFacetItems),
+    [searchFacetFilters],
+  );
+
+  return useMemo(() => updatedFacetFilter.map(({
     title, attribute, isSortedAlphabetical, typeaheadOptions, noDisplay,
   }) => (
     <FacetListRefinement
@@ -42,15 +54,15 @@ const NewContentAwareSearchFilters = ({ variant }) => {
       variant={variant}
       noDisplay={noDisplay}
     />
-  ));
+  )), [updatedFacetFilter, refinements, variant]);
 };
 
-NewContentAwareSearchFilters.propTypes = {
+SearchFacetFiltersOverride.propTypes = {
   variant: PropTypes.string,
 };
 
-NewContentAwareSearchFilters.defaultProps = {
+SearchFacetFiltersOverride.defaultProps = {
   variant: 'inverse',
 };
 
-export default NewContentAwareSearchFilters;
+export default SearchFacetFiltersOverride;

--- a/src/components/catalogs/SearchFacetFiltersOverride.test.jsx
+++ b/src/components/catalogs/SearchFacetFiltersOverride.test.jsx
@@ -1,7 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import { SearchContext } from '@2uinc/frontend-enterprise-catalog-search';
 import '@testing-library/jest-dom/extend-expect';
-import NewContentAwareSearchFilters from './NewContentAwareSearchFilters';
+import SearchFacetFiltersOverride from './SearchFacetFiltersOverride';
+import mockFeatures from '../../config';
+
+jest.mock('../../config', () => ({
+  __esModule: true,
+  default: { NEW_CONTENT_FACET: false },
+}));
 
 const capturedTransforms = {};
 
@@ -31,13 +37,14 @@ const baseFacets = [
 
 const renderWithContext = (searchFacetFilters, refinements = {}) => render(
   <SearchContext.Provider value={{ refinements, searchFacetFilters }}>
-    <NewContentAwareSearchFilters />
+    <SearchFacetFiltersOverride />
   </SearchContext.Provider>,
 );
 
-describe('NewContentAwareSearchFilters', () => {
+describe('SearchFacetFiltersOverride', () => {
   beforeEach(() => {
     Object.keys(capturedTransforms).forEach((key) => delete capturedTransforms[key]);
+    mockFeatures.NEW_CONTENT_FACET = false;
   });
 
   it('renders one cell per facet from SearchContext', () => {
@@ -54,6 +61,7 @@ describe('NewContentAwareSearchFilters', () => {
   });
 
   it('transformItems for is_new_content keeps only the true row with original label preserved', () => {
+    mockFeatures.NEW_CONTENT_FACET = true;
     const facets = [
       { attribute: 'is_new_content', title: 'Latest Offerings' },
     ];
@@ -68,12 +76,31 @@ describe('NewContentAwareSearchFilters', () => {
     ]);
   });
 
-  it('renders is_new_content facet alongside other facets', () => {
+  it('renders is_new_content facet alongside other facets when the flag is on', () => {
+    mockFeatures.NEW_CONTENT_FACET = true;
     const facets = [
       ...baseFacets,
       { attribute: 'is_new_content', title: 'Latest Offerings' },
     ];
     renderWithContext(facets);
     expect(screen.getByTestId('facet-is_new_content')).toBeInTheDocument();
+  });
+
+  it('omits the is_new_content facet entirely when the flag is off', () => {
+    mockFeatures.NEW_CONTENT_FACET = false;
+    const facets = [
+      ...baseFacets,
+      { attribute: 'is_new_content', title: 'Latest Offerings' },
+    ];
+    renderWithContext(facets);
+    expect(screen.getByTestId('facet-skill_names')).toBeInTheDocument();
+    expect(screen.queryByTestId('facet-is_new_content')).not.toBeInTheDocument();
+  });
+
+  it('still renders unrelated facets when the flag is off', () => {
+    mockFeatures.NEW_CONTENT_FACET = false;
+    renderWithContext(baseFacets);
+    expect(screen.getByTestId('facet-skill_names')).toBeInTheDocument();
+    expect(screen.getByTestId('facet-partners.name')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Renames `NewContentAwareSearchFilters` -> `SearchFacetFiltersOverride`, and fixes the root cause of all filters disappearing on stage.

**Root cause:** `filterComponents={flag && (<Component />)}` evaluates to `false` when the flag is off. The shared package does `filterComponents ?? defaultSearchFacets`, and `??` only falls back on `null`/`undefined` - not `false`. So passing `false` rendered nothing at all, not just the new facet.

**Fix:** always mount `SearchFacetFiltersOverride`; it now decides internally whether to include `is_new_content`, via `filterFacetItems`. Every other facet always passes through unchanged.

ENT-12100