### PR TITLE
feat: add course end on the explore catalog course card page

### DIFF
--- a/src/components/catalogInfoModal/CatalogInfoModal.test.jsx
+++ b/src/components/catalogInfoModal/CatalogInfoModal.test.jsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import CatalogInfoModal from './CatalogInfoModal';
 import features from '../../config';
+import { formatSessionDate } from '../../utils/catalogUtils';
 
 const descriptionText = 'this is a description';
 // course descriptions are injected into the DOM with dangerouslySetInnerHTML
@@ -88,7 +89,7 @@ describe('Course info modal works as expected', () => {
     );
     expect(screen.queryByText('A la carte course price')).toBeInTheDocument();
     expect(
-      screen.queryByText('Session ends Apr 6, 2040 • 2 additional session(s)'),
+      screen.queryByText(`Session starts ${formatSessionDate(new Date('2021-09-15T16:00:00Z'))} | Session ends ${formatSessionDate(new Date('2040-04-06T16:00:00Z'))} • 2 additional session(s)`),
     ).toBeInTheDocument();
     expect(
       screen.queryByText('Included with subscription'),
@@ -234,7 +235,9 @@ describe('Executive Education info modal works as expected', () => {
     expect(screen.queryByText('100')).toBeInTheDocument();
     expect(screen.queryByText('Executive Education')).toBeInTheDocument();
     expect(screen.queryByText('Immersive, instructor-led course')).toBeInTheDocument();
-    expect(screen.queryByText('Session ends May 4, 2040'));
+    expect(
+      screen.queryByText(`Session starts ${formatSessionDate(new Date('2020-09-15T16:00:00Z'))} | Session ends ${formatSessionDate(new Date('2040-05-04T16:00:00Z'))}`),
+    ).toBeInTheDocument();
   });
 });
 

--- a/src/components/catalogModalBanner/CatalogCourseModalBanner.jsx
+++ b/src/components/catalogModalBanner/CatalogCourseModalBanner.jsx
@@ -7,33 +7,16 @@ import {
 } from '@openedx/paragon/icons';
 import messages from './CatalogCourseModalBanner.messages';
 import {
+  AVAILABILITY_STATUS,
+  availabilitySubtitle,
   checkAvailability,
   checkSubscriptions,
 } from '../../utils/catalogUtils';
 
-const nowDate = new Date(Date.now());
-
-function availabilitySubtitle(start, end, upcomingRuns) {
-  let retString = '';
-  const options = { year: 'numeric', month: 'short', day: 'numeric' };
-  const startDate = new Date(start);
-  const endDate = new Date(end);
-  if (startDate < nowDate && endDate > nowDate) {
-    retString = `Session ends ${endDate.toLocaleDateString(
-      undefined,
-      options,
-    )}`;
-  } else if (startDate > nowDate) {
-    retString = `Session starts ${startDate.toLocaleDateString(
-      undefined,
-      options,
-    )}`;
-  }
-  if (upcomingRuns !== undefined && upcomingRuns > 0) {
-    retString += ` • ${upcomingRuns} additional session(s)`;
-  }
-  return retString;
-}
+const AVAILABILITY_MESSAGE_KEYS = {
+  [AVAILABILITY_STATUS.AVAILABLE_NOW]: 'CatalogCourseModalBanner.availableNow',
+  [AVAILABILITY_STATUS.STARTING_SOON]: 'CatalogCourseModalBanner.startingSoon',
+};
 
 const CatalogCourseModalBanner = ({
   coursePrice,
@@ -44,6 +27,9 @@ const CatalogCourseModalBanner = ({
   execEd,
 }) => {
   const intl = useIntl();
+  const availabilityStatus = checkAvailability(startDate, endDate);
+  const availabilityMessageKey = AVAILABILITY_MESSAGE_KEYS[availabilityStatus];
+  const availabilityLabel = availabilityMessageKey ? intl.formatMessage(messages[availabilityMessageKey]) : '';
 
   return (
     <div className="banner my-3">
@@ -96,7 +82,7 @@ const CatalogCourseModalBanner = ({
       <div className="banner-section mx-3">
         <div className="banner h4 mb-0">
           <Icon className="mr-1" src={EventNote} />
-          {checkAvailability(startDate, endDate)}
+          {availabilityLabel}
         </div>
         <div className="banner-subtitle small">
           {availabilitySubtitle(startDate, endDate, upcomingRuns)}{' '}

--- a/src/components/catalogModalBanner/CatalogCourseModalBanner.messages.js
+++ b/src/components/catalogModalBanner/CatalogCourseModalBanner.messages.js
@@ -31,6 +31,16 @@ const messages = defineMessages({
     defaultMessage: 'Immersive, instructor-led course',
     description: 'Text for modal subheader banner for exec ed courses.',
   },
+  'CatalogCourseModalBanner.availableNow': {
+    id: 'CatalogCourseModalBanner.availableNow',
+    defaultMessage: 'Available now',
+    description: 'Availability label shown in the course modal banner when the advertised session has already started.',
+  },
+  'CatalogCourseModalBanner.startingSoon': {
+    id: 'CatalogCourseModalBanner.startingSoon',
+    defaultMessage: 'Starting soon',
+    description: 'Availability label shown in the course modal banner when the advertised session has not started yet.',
+  },
 });
 
 export default messages;

--- a/src/components/catalogModalBanner/CatalogCourseModalBanner.test.jsx
+++ b/src/components/catalogModalBanner/CatalogCourseModalBanner.test.jsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+
+import CatalogCourseModalBanner from './CatalogCourseModalBanner';
+import { formatSessionDate } from '../../utils/catalogUtils';
+
+const renderBanner = (props) => render(
+  <IntlProvider locale="en">
+    <CatalogCourseModalBanner coursePrice="$399.00" {...props} />
+  </IntlProvider>,
+);
+
+describe('<CatalogCourseModalBanner />', () => {
+  test('renders both start and end dates together when both are known', () => {
+    renderBanner({
+      startDate: '2026-08-16T00:00:00Z',
+      endDate: '2026-10-14T00:00:00Z',
+    });
+    expect(
+      screen.getByText(`Session starts ${formatSessionDate(new Date('2026-08-16T00:00:00Z'))} | Session ends ${formatSessionDate(new Date('2026-10-14T00:00:00Z'))}`),
+    ).toBeInTheDocument();
+  });
+
+  test('appends the upcoming session count when both dates are known', () => {
+    renderBanner({
+      startDate: '2026-08-16T00:00:00Z',
+      endDate: '2026-10-14T00:00:00Z',
+      upcomingRuns: 2,
+    });
+    expect(
+      screen.getByText(`Session starts ${formatSessionDate(new Date('2026-08-16T00:00:00Z'))} | Session ends ${formatSessionDate(new Date('2026-10-14T00:00:00Z'))} • 2 additional session(s)`),
+    ).toBeInTheDocument();
+  });
+
+  test('falls back to only the end date when the course has already started', () => {
+    renderBanner({ endDate: '2080-01-01T00:00:00Z' });
+    expect(
+      screen.getByText(new RegExp(`^Session ends ${formatSessionDate(new Date('2080-01-01T00:00:00Z'))}$`)),
+    ).toBeInTheDocument();
+  });
+
+  test('falls back to only the start date when the end date is unknown', () => {
+    const futureStart = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    renderBanner({ startDate: futureStart });
+    expect(screen.getByText(/^Session starts /)).toBeInTheDocument();
+  });
+
+  test('renders no session date text when no dates are known', () => {
+    renderBanner({});
+    expect(screen.queryByText(/Session (starts|ends)/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/catalogSearchResults/CatalogSearchResults.test.jsx
+++ b/src/components/catalogSearchResults/CatalogSearchResults.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  act, render, screen, waitFor,
+  act, render, screen, waitFor, within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
@@ -14,6 +14,7 @@ import {
 } from './CatalogSearchResults';
 import { renderWithRouter } from '../tests/testUtils';
 import messages from './CatalogSearchResults.messages';
+import { formatSessionDate } from '../../utils/catalogUtils';
 import {
   CONTENT_TYPE_COURSE,
   CONTENT_TYPE_PROGRAM,
@@ -445,7 +446,9 @@ describe('Main Catalogs view works as expected', () => {
     const courseTitle = screen.getByText('test course');
     await user.click(courseTitle);
 
-    await waitFor(() => expect(screen.queryByText('Session ends Jan 1, 2080')).toBeInTheDocument());
+    await waitFor(() => expect(
+      screen.queryByText(`Session starts ${formatSessionDate(new Date('2020-01-24T05:00:00Z'))} | Session ends ${formatSessionDate(new Date('2080-01-01T17:00:00Z'))}`),
+    ).toBeInTheDocument());
     await waitFor(() => expect(screen.queryByText('About this course')).toBeInTheDocument());
   });
   test('testing card course modal pops up ', async () => {
@@ -463,7 +466,12 @@ describe('Main Catalogs view works as expected', () => {
     const user = userEvent.setup();
     await user.click(courseTitle);
     await waitFor(() => expect(screen.queryByText('A la carte course price')).toBeInTheDocument());
-    await waitFor(() => expect(screen.queryByText('Session ends Jan 1, 2080')).toBeInTheDocument());
+    await waitFor(() => {
+      const dialog = within(screen.getByRole('dialog'));
+      expect(
+        dialog.queryByText(`Session starts ${formatSessionDate(new Date('2020-01-24T05:00:00Z'))} | Session ends ${formatSessionDate(new Date('2080-01-01T17:00:00Z'))}`),
+      ).toBeInTheDocument();
+    });
     await act(() => screen.findByText('About this course'));
     await waitFor(() => expect(screen.queryByText('About this course')).toBeInTheDocument());
   });

--- a/src/components/courseCard/CourseCard.jsx
+++ b/src/components/courseCard/CourseCard.jsx
@@ -2,11 +2,18 @@
 // variables taken from algolia not in camelcase
 import PropTypes from 'prop-types';
 
-import { Badge, Card } from '@openedx/paragon';
+import { Badge, Card, Icon } from '@openedx/paragon';
+import { EventNote } from '@openedx/paragon/icons';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import messages from './CourseCard.messages';
 import defaultCardHeader from '../../static/default-card-header-light.png';
 import { formatPrice } from '../../utils/common';
+import { AVAILABILITY_STATUS, availabilitySubtitle, checkAvailability } from '../../utils/catalogUtils';
+
+const AVAILABILITY_MESSAGE_KEYS = {
+  [AVAILABILITY_STATUS.AVAILABLE_NOW]: 'courseCard.availableNow',
+  [AVAILABILITY_STATUS.STARTING_SOON]: 'courseCard.startingSoon',
+};
 
 const CourseCard = ({ onClick, original }) => {
   const intl = useIntl();
@@ -23,6 +30,12 @@ const CourseCard = ({ onClick, original }) => {
   if (advertised_course_run) {
     pacingType = advertised_course_run.pacing_type === 'self_paced' ? 'Self paced' : 'Instructor led';
   }
+  const courseRunStart = advertised_course_run?.start;
+  const courseRunEnd = advertised_course_run?.end;
+  const availabilityStatus = checkAvailability(courseRunStart, courseRunEnd);
+  const availabilityMessageKey = AVAILABILITY_MESSAGE_KEYS[availabilityStatus];
+  const availabilityLabel = availabilityMessageKey ? intl.formatMessage(messages[availabilityMessageKey]) : '';
+  const courseDatesText = availabilitySubtitle(courseRunStart, courseRunEnd);
 
   const imageSrc = card_image_url || defaultCardHeader;
   const altText = `${title} course image`;
@@ -46,6 +59,19 @@ const CourseCard = ({ onClick, original }) => {
         <p className="my-3">
           {priceText} • {pacingType}
         </p>
+        {courseDatesText && (
+          <div className="mb-3">
+            {availabilityLabel && (
+              <div className="h6 mb-0 d-flex align-items-center">
+                <Icon className="mr-1" src={EventNote} />
+                {availabilityLabel}
+              </div>
+            )}
+            <p className="small mb-0">
+              {courseDatesText}
+            </p>
+          </div>
+        )}
         <div style={{ maxWidth: '400vw' }}>
           {enterprise_catalog_query_titles?.includes(
             process.env.EDX_ENTERPRISE_ALACARTE_TITLE,

--- a/src/components/courseCard/CourseCard.messages.jsx
+++ b/src/components/courseCard/CourseCard.messages.jsx
@@ -22,6 +22,16 @@ const messages = defineMessages({
     description:
       'When a course price is not available, notify learners that there is no data available to display.',
   },
+  'courseCard.availableNow': {
+    id: 'courseCard.availableNow',
+    defaultMessage: 'Available now',
+    description: 'Availability label shown on a course card when the advertised session has already started.',
+  },
+  'courseCard.startingSoon': {
+    id: 'courseCard.startingSoon',
+    defaultMessage: 'Starting soon',
+    description: 'Availability label shown on a course card when the advertised session has not started yet.',
+  },
 });
 
 export default messages;

--- a/src/components/courseCard/CourseCard.test.jsx
+++ b/src/components/courseCard/CourseCard.test.jsx
@@ -6,6 +6,7 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import CourseCard from './CourseCard';
 import { CONTENT_TYPE_COURSE, EXEC_ED_TITLE } from '../../constants';
 import features from '../../config';
+import { formatSessionDate } from '../../utils/catalogUtils';
 
 jest.mock('@edx/frontend-platform', () => ({
   ...jest.requireActual('@edx/frontend-platform'),
@@ -107,5 +108,51 @@ describe('Course card works as expected', () => {
     // price decimal should be truncated
     expect(screen.queryByText('$999 • Instructor led')).toBeInTheDocument();
     expect(screen.queryByText('Subscription')).toBeInTheDocument();
+  });
+  test('card does not render course dates when the course run has no start/end date', () => {
+    render(
+      <IntlProvider locale="en">
+        <CourseCard {...defaultProps} />
+      </IntlProvider>,
+    );
+    expect(screen.queryByText(/Session (starts|ends)/)).not.toBeInTheDocument();
+  });
+  test('card renders course start and end dates and availability label when present on the advertised course run', () => {
+    const dataWithDates = {
+      ...originalData,
+      advertised_course_run: {
+        pacing_type: 'self_paced',
+        start: '2020-01-24T05:00:00Z',
+        end: '2080-01-01T17:00:00Z',
+      },
+    };
+    render(
+      <IntlProvider locale="en">
+        <CourseCard original={dataWithDates} />
+      </IntlProvider>,
+    );
+    expect(screen.queryByText('Available now')).toBeInTheDocument();
+    expect(
+      screen.queryByText(`Session starts ${formatSessionDate(new Date('2020-01-24T05:00:00Z'))} | Session ends ${formatSessionDate(new Date('2080-01-01T17:00:00Z'))}`),
+    ).toBeInTheDocument();
+  });
+  test('card renders dates subtitle without an availability label when only an end date is known', () => {
+    const dataWithEndOnly = {
+      ...originalData,
+      advertised_course_run: {
+        pacing_type: 'self_paced',
+        end: '2080-01-01T17:00:00Z',
+      },
+    };
+    render(
+      <IntlProvider locale="en">
+        <CourseCard original={dataWithEndOnly} />
+      </IntlProvider>,
+    );
+    expect(screen.queryByText('Available now')).not.toBeInTheDocument();
+    expect(screen.queryByText('Starting soon')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(`Session ends ${formatSessionDate(new Date('2080-01-01T17:00:00Z'))}`),
+    ).toBeInTheDocument();
   });
 });

--- a/src/utils/catalogUtils.test.js
+++ b/src/utils/catalogUtils.test.js
@@ -1,5 +1,12 @@
 import { EXEC_ED_TITLE } from '../constants';
-import { convertLearningTypesToFilters, createQueryParams } from './catalogUtils';
+import {
+  AVAILABILITY_STATUS,
+  availabilitySubtitle,
+  checkAvailability,
+  convertLearningTypesToFilters,
+  createQueryParams,
+  formatSessionDate,
+} from './catalogUtils';
 
 describe('catalogUtils', () => {
   it('converts lists of learning types to algolia filters', () => {
@@ -20,5 +27,64 @@ describe('catalogUtils', () => {
     const expectedQueryParams = 'enterprise_catalog_query_titles=A+la+carte&availability=Available+Now&availability=Starting+Soon';
     const queryParams = createQueryParams(options);
     expect(queryParams).toEqual(expectedQueryParams);
+  });
+
+  describe('checkAvailability', () => {
+    it('returns AVAILABLE_NOW when the session has started but not ended', () => {
+      expect(checkAvailability('2020-01-24T05:00:00Z', '2080-01-01T17:00:00Z'))
+        .toEqual(AVAILABILITY_STATUS.AVAILABLE_NOW);
+    });
+
+    it('returns STARTING_SOON when the session has not started yet', () => {
+      const futureStart = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+      expect(checkAvailability(futureStart, '2080-01-01T17:00:00Z')).toEqual(AVAILABILITY_STATUS.STARTING_SOON);
+    });
+
+    it('returns an empty string when the session has already ended', () => {
+      expect(checkAvailability('2019-01-24T05:00:00Z', '2020-01-01T17:00:00Z')).toEqual(AVAILABILITY_STATUS.NONE);
+    });
+
+    it('returns an empty string when the start date is missing/invalid, even if the end date is in the future', () => {
+      expect(checkAvailability(undefined, '2080-01-01T17:00:00Z')).toEqual(AVAILABILITY_STATUS.NONE);
+    });
+  });
+
+  describe('availabilitySubtitle', () => {
+    it('shows both start and end dates together when both are known', () => {
+      expect(availabilitySubtitle('2020-01-24T05:00:00Z', '2080-01-01T17:00:00Z')).toEqual(
+        `Session starts ${formatSessionDate(new Date('2020-01-24T05:00:00Z'))} | Session ends ${formatSessionDate(new Date('2080-01-01T17:00:00Z'))}`,
+      );
+    });
+
+    it('appends the upcoming session count when both dates are known', () => {
+      expect(availabilitySubtitle('2020-01-24T05:00:00Z', '2080-01-01T17:00:00Z', 3)).toEqual(
+        `Session starts ${formatSessionDate(new Date('2020-01-24T05:00:00Z'))} | Session ends ${formatSessionDate(new Date('2080-01-01T17:00:00Z'))} • 3 additional session(s)`,
+      );
+    });
+
+    it('falls back to only the end date when the start date is unknown', () => {
+      expect(availabilitySubtitle(undefined, '2080-01-01T17:00:00Z')).toEqual(
+        `Session ends ${formatSessionDate(new Date('2080-01-01T17:00:00Z'))}`,
+      );
+    });
+
+    it('falls back to only the start date when the end date is unknown', () => {
+      const futureStart = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+      expect(availabilitySubtitle(futureStart, undefined)).toEqual(
+        `Session starts ${formatSessionDate(new Date(futureStart))}`,
+      );
+    });
+
+    it('returns an empty string when neither date is known', () => {
+      expect(availabilitySubtitle(undefined, undefined)).toEqual('');
+    });
+
+    it('returns an empty string when both dates are known but the session has already ended', () => {
+      expect(availabilitySubtitle('2019-01-24T05:00:00Z', '2020-01-01T17:00:00Z')).toEqual('');
+    });
+
+    it('does not prepend the upcoming-runs suffix onto an empty base string', () => {
+      expect(availabilitySubtitle('2019-01-24T05:00:00Z', '2020-01-01T17:00:00Z', 2)).toEqual('');
+    });
   });
 });

--- a/src/utils/catalogUtils.ts
+++ b/src/utils/catalogUtils.ts
@@ -1,7 +1,25 @@
 import { EXEC_ED_TITLE } from '../constants';
 
 /* eslint-disable import/prefer-default-export */
-const nowDate = new Date(Date.now());
+
+const AVAILABILITY_STATUS = {
+  AVAILABLE_NOW: 'available_now',
+  STARTING_SOON: 'starting_soon',
+  NONE: '',
+} as const;
+
+function isValidDate(date: Date): boolean {
+  return !Number.isNaN(date.getTime());
+}
+
+/**
+ * Formats a Date the same way everywhere a session start/end date is displayed, so callers
+ * (and tests) never re-derive this formatting independently.
+ */
+function formatSessionDate(date: Date): string {
+  const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric' };
+  return date.toLocaleDateString(undefined, options);
+}
 
 function checkSubscriptions(courseAssociatedCatalogs) {
   const inSubscription = courseAssociatedCatalogs.includes(
@@ -13,16 +31,50 @@ function checkSubscriptions(courseAssociatedCatalogs) {
   return false;
 }
 
-function checkAvailability(start, end) {
+/**
+ * Returns one of `AVAILABILITY_STATUS`'s values describing a session's availability. Callers are
+ * responsible for mapping the returned status to localized display text (via
+ * `intl.formatMessage`) rather than rendering it directly.
+ */
+function checkAvailability(start, end): string {
+  const nowDate = new Date(Date.now());
   const startDate = new Date(start);
   const endDate = new Date(end);
-  if (startDate < nowDate && endDate > nowDate) {
-    return 'Available now';
+  const hasValidStart = !!start && isValidDate(startDate);
+  const hasValidEnd = !!end && isValidDate(endDate);
+  if (hasValidStart && hasValidEnd && startDate < nowDate && endDate > nowDate) {
+    return AVAILABILITY_STATUS.AVAILABLE_NOW;
   }
-  if (startDate > nowDate) {
-    return 'Starting soon';
+  if (hasValidStart && startDate > nowDate) {
+    return AVAILABILITY_STATUS.STARTING_SOON;
   }
-  return '';
+  return AVAILABILITY_STATUS.NONE;
+}
+
+/**
+ * Builds a human-readable session date subtitle, e.g. "Session starts Aug 16, 2026 | Session
+ * ends Oct 14, 2026". Shows both dates together whenever both are known and the session hasn't
+ * ended yet; falls back to whichever single date is known and still relevant, or an empty string
+ * when neither is known or the session has already ended.
+ */
+function availabilitySubtitle(start, end, upcomingRuns?: number) {
+  const nowDate = new Date(Date.now());
+  let retString = '';
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  const hasValidStart = !!start && isValidDate(startDate);
+  const hasValidEnd = !!end && isValidDate(endDate);
+  if (hasValidStart && hasValidEnd && endDate > nowDate) {
+    retString = `Session starts ${formatSessionDate(startDate)} | Session ends ${formatSessionDate(endDate)}`;
+  } else if (hasValidEnd && endDate > nowDate) {
+    retString = `Session ends ${formatSessionDate(endDate)}`;
+  } else if (hasValidStart && startDate > nowDate) {
+    retString = `Session starts ${formatSessionDate(startDate)}`;
+  }
+  if (upcomingRuns !== undefined && upcomingRuns > 0 && retString) {
+    retString += ` • ${upcomingRuns} additional session(s)`;
+  }
+  return retString;
 }
 
 function convertLearningTypesToFilters(types) {
@@ -60,5 +112,11 @@ function createQueryParams(options: Record<string, any>): string {
 }
 
 export {
-  checkAvailability, checkSubscriptions, convertLearningTypesToFilters, createQueryParams,
+  AVAILABILITY_STATUS,
+  availabilitySubtitle,
+  checkAvailability,
+  checkSubscriptions,
+  convertLearningTypesToFilters,
+  createQueryParams,
+  formatSessionDate,
 };


### PR DESCRIPTION
JIRA Work Item:- https://2u-internal.atlassian.net/browse/ENT-11142

Changes Implemented:-
This PR extracts the availabilitySubtitle helper from CatalogCourseModalBanner.jsx into the shared catalogUtils.ts utility, extends it to display both session start and end dates when both are available, and reuses the shared logic in the Explore Catalog CourseCard to surface course availability and session dates directly on course cards.


- [ ] Moved `availabilitySubtitle` from **CatalogCourseModalBanner.jsx** to **src/utils/catalogUtils.ts**.
- [ ] Enhance `availabilitySubtitle` to display both start and end dates when both dates are available.
- [ ] Reuse availabilitySubtitle and checkAvailability in CourseCard instead of maintaining separate logic.
- [ ] Display course availability label (e.g. Available now) and session dates on Explore Catalog course cards.
- [ ] Updated unit test cases

Attached screenshots:-

<img width="423" height="252" alt="image" src="https://github.com/user-attachments/assets/78c59d1c-2464-43a0-8f48-79cd06bbdd4c" />
