### PR TITLE
fix: use a fixed 700px height for the lead-gen iframe

### DIFF
--- a/src/components/leadGenModal/LeadGenModal.jsx
+++ b/src/components/leadGenModal/LeadGenModal.jsx
@@ -43,7 +43,6 @@ const LeadGenModal = ({ isOpen, onClose, onSubmitted }) => {
       size="lg"
       hasCloseButton={false}
       isFullscreenOnMobile
-      isOverflowVisible
       className="lead-gen-modal"
     >
       <ModalDialog.Body>
@@ -57,7 +56,7 @@ const LeadGenModal = ({ isOpen, onClose, onSubmitted }) => {
               />
             </h2>
             {!isIframeLoaded && (
-              <div className="d-flex justify-content-center align-items-center" style={{ height: 500 }}>
+              <div className="d-flex justify-content-center align-items-center" style={{ height: 700 }}>
                 <Spinner animation="border" screenReaderText="Loading form" />
               </div>
             )}
@@ -66,9 +65,10 @@ const LeadGenModal = ({ isOpen, onClose, onSubmitted }) => {
               title="Catalog download request form"
               src={src}
               width="100%"
-              height="500"
+              height="700"
               type="text/html"
               frameBorder="0"
+              scrolling="no"
               // allow-scripts/-forms/-same-origin: what Pardot needs to validate, submit,
               // and read its own tracking cookies. allow-popups: the embed's "Privacy
               // Statement" link opens in a new tab. Deliberately omits allow-top-navigation

--- a/src/components/leadGenModal/LeadGenModal.test.jsx
+++ b/src/components/leadGenModal/LeadGenModal.test.jsx
@@ -48,9 +48,10 @@ describe('LeadGenModal', () => {
     renderWithRouter(<LeadGenModal {...defaultProps} />);
     const iframe = screen.getByTitle('Catalog download request form');
     expect(iframe).toHaveAttribute('width', '100%');
-    expect(iframe).toHaveAttribute('height', '500');
+    expect(iframe).toHaveAttribute('height', '700');
     expect(iframe).toHaveAttribute('type', 'text/html');
     expect(iframe).toHaveAttribute('frameBorder', '0');
+    expect(iframe).toHaveAttribute('scrolling', 'no');
     expect(iframe).toHaveStyle({ border: '0' });
   });
 


### PR DESCRIPTION
Summary
The lead-gen modal's iframe was fixed at height="500", matching the marketing-provided embed snippet from the ticket. Since then, Pardot's form has grown (added Job Role, Job Function, and Organization Type fields), so the embedded content no longer fits in 500px. Combined with isOverflowVisible disabling the modal's own scroll handling, this produced two nested scrollbars, one native to the iframe, one from whatever was left to scroll the modal — and validation-error text pushed the form even taller, making the Submit button hard to reach.

This PR:

Removes isOverflowVisible so Paragon's built-in modal-body scrolling (overflow: auto) applies normally instead of being turned off.
Bumps the iframe (and its loading-spinner placeholder) from 500px to 700px so the current field count fits without the iframe needing to scroll internally in normal use.
Adds scrolling="no" to the iframe so it can never independently scroll — the modal body is the single scroll owner going forward.
Flagging for awareness: the ticket's iframe snippet specifies height="500", which predates these extra fields. This PR intentionally deviates from that literal spec since matching it would leave later fields unreachable.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots

**Bug:** 
<img width="1014" height="637" alt="image" src="https://github.com/user-attachments/assets/d7634392-ef78-4876-bb47-31eada69539f" />

**fix:** 
<img width="1101" height="613" alt="image" src="https://github.com/user-attachments/assets/13ebc7df-e05e-4074-9fd6-ba48ee86f919" />


