### PR TITLE
fix: use American spelling catalog in modal title

### DIFF
--- a/src/components/leadGenModal/LeadGenModal.jsx
+++ b/src/components/leadGenModal/LeadGenModal.jsx
@@ -51,7 +51,7 @@ const LeadGenModal = ({ isOpen, onClose, onSubmitted }) => {
             <h2 className="h4 lead-gen-modal-title">
               <FormattedMessage
                 id="leadGenModal.title"
-                defaultMessage="Complete to download your custom catalogue"
+                defaultMessage="Complete to download your custom catalog"
                 description="Title shown above the lead gen form explaining what completing it unlocks."
               />
             </h2>


### PR DESCRIPTION

<img width="618" height="479" alt="image" src="https://github.com/user-attachments/assets/4564929b-1715-4d95-beeb-46da9aa03912" />


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
